### PR TITLE
feat(export): harden mapping/passport/dxf scripts

### DIFF
--- a/scripts/export_mapping.py
+++ b/scripts/export_mapping.py
@@ -1,88 +1,185 @@
 #!/usr/bin/env python3
-import json
-from uuid import uuid4
-from datetime import datetime, timezone
+from __future__ import annotations
 
-def map_snapshot_to_export_config(snapshot_data: dict, project_id: str) -> dict:
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+DEFAULT_ARTICLE = "100001.1"
+DEFAULT_FRAME = {"width": 1200, "height": 2500, "depth": 200}
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _as_int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list_of_dicts(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, dict)]
+
+
+def _sorted_edges(graph: dict[str, Any]) -> list[dict[str, Any]]:
+    edges = _as_list_of_dicts(graph.get("edges"))
+    return sorted(
+        edges,
+        key=lambda e: (
+            str(e.get("from", "")),
+            str(e.get("to", "")),
+            str(e.get("type", "")),
+        ),
+    )
+
+
+def _sorted_nodes(graph: dict[str, Any]) -> list[dict[str, Any]]:
+    raw_nodes = graph.get("nodes")
+    if isinstance(raw_nodes, dict):
+        nodes = [v for v in raw_nodes.values() if isinstance(v, dict)]
+    else:
+        nodes = _as_list_of_dicts(raw_nodes)
+    return sorted(nodes, key=lambda n: str(n.get("id", "")))
+
+
+def _default_segment(frame_height: int) -> dict[str, Any]:
+    return {
+        "type": "segment",
+        "start": {"x": 0, "y": 0, "z": 0},
+        "end": {"x": 0, "y": frame_height, "z": 0},
+    }
+
+
+def map_snapshot_to_export_config(snapshot_data: dict[str, Any], project_id: str) -> dict[str, Any]:
     """
-    Transforms a ConfigurationSnapshot into a RivoExportConfig format.
-    - ConfigurationSnapshot contains `stateId`, `dimensions`, `graph`, `bom`
-    - RivoExportConfig maps graph -> elements[], bom -> bom.lines[]
+    Transform ConfigurationSnapshot into RivoExportConfig.
+    Keeps deterministic ordering for export stability.
     """
-    rivo_config = {
+    if not isinstance(snapshot_data, dict):
+        raise ValueError("snapshot_data must be a dictionary")
+    if not project_id.strip():
+        raise ValueError("project_id must not be empty")
+
+    dimensions = _as_dict(snapshot_data.get("dimensions"))
+    frame_height = _as_int(dimensions.get("height"), DEFAULT_FRAME["height"])
+
+    rivo_config: dict[str, Any] = {
         "meta": {
             "projectId": project_id,
-            "createdAt": datetime.now(timezone.utc).isoformat(),
+            "snapshotStateId": snapshot_data.get("stateId"),
+            "createdAt": _utc_now_iso(),
             "units": "mm",
             "version": "1.0.0",
-            "author": "RIVO Configurator"
+            "author": "RIVO Configurator",
         },
         "frame": {
             "type": "falsewall",
-            "width": snapshot_data.get("dimensions", {}).get("width", 1200),
-            "height": snapshot_data.get("dimensions", {}).get("height", 2500),
-            "depth": snapshot_data.get("dimensions", {}).get("depth", 200),
+            "width": _as_int(dimensions.get("width"), DEFAULT_FRAME["width"]),
+            "height": frame_height,
+            "depth": _as_int(dimensions.get("depth"), DEFAULT_FRAME["depth"]),
             "studStep": 600,
             "origin": {"x": 0, "y": 0, "z": 0},
             "grid": {"snapMm": 1, "roundMm": 0.1},
             "constraints": {
                 "maxWaterPressureBar": 6,
                 "recommendedFilterMicron": 100,
-                "waterStandard": "GOST 2874-82"
-            }
+                "waterStandard": "GOST 2874-82",
+            },
         },
-        "catalog": {
-            "items": [] # Catalog items could be resolved via a registry
-        },
+        "catalog": {"items": []},
         "elements": [],
-        "bom": {
-            "lines": snapshot_data.get("bom", [])
-        },
+        "bom": {"lines": _as_list_of_dicts(snapshot_data.get("bom"))},
         "views": {
             "front": {"mode": "cad", "dimensions": []},
-            "side": {"mode": "cad", "dimensions": []}
-        }
+            "side": {"mode": "cad", "dimensions": []},
+        },
     }
 
-    # Map StructureGraph edges and nodes to Elements array (simplified representation)
-    graph = snapshot_data.get("graph", {})
-    edges = graph.get("edges", [])
-    
-    # Normally, graph nodes hold the geometry and article data. We dummy map here.
-    for i, edge in enumerate(edges):
-        element = {
-            "id": f"mapped-elem-{i}",
-            "article": "100001.1", # Default placeholder
-            "kind": "profile",
-            "transform": {"pos": {"x": 0, "y": 0, "z": 0}, "rot": {"rx": 0, "ry": 0, "rz": 0}},
-            "geom": {
-                "type": "segment",
-                "start": {"x": 0, "y": 0, "z": 0},
-                "end": {"x": 0, "y": rivo_config["frame"]["height"], "z": 0}
-            },
-            "connections": [
-                {"to": edge.get("to", ""), "type": edge.get("type", "corner")}
-            ]
-        }
-        rivo_config["elements"].append(element)
+    graph = _as_dict(snapshot_data.get("graph"))
+    edges = _sorted_edges(graph)
+    nodes = _sorted_nodes(graph)
+
+    if nodes:
+        outgoing_map: dict[str, list[dict[str, str]]] = {}
+        for edge in edges:
+            src = str(edge.get("from", ""))
+            if not src:
+                continue
+            outgoing_map.setdefault(src, []).append(
+                {"to": str(edge.get("to", "")), "type": str(edge.get("type", "corner"))}
+            )
+
+        for node in nodes:
+            node_id = str(node.get("id", "")).strip() or f"node-{len(rivo_config['elements'])}"
+            geom = _as_dict(node.get("geom")) or _default_segment(frame_height)
+            element = {
+                "id": node_id,
+                "article": str(node.get("article", DEFAULT_ARTICLE)),
+                "kind": str(node.get("kind", "profile")),
+                "transform": _as_dict(node.get("transform"))
+                or {"pos": {"x": 0, "y": 0, "z": 0}, "rot": {"rx": 0, "ry": 0, "rz": 0}},
+                "geom": geom,
+                "connections": outgoing_map.get(node_id, []),
+            }
+            rivo_config["elements"].append(element)
+    else:
+        for index, edge in enumerate(edges):
+            element = {
+                "id": f"mapped-elem-{index}",
+                "article": DEFAULT_ARTICLE,
+                "kind": "profile",
+                "transform": {"pos": {"x": 0, "y": 0, "z": 0}, "rot": {"rx": 0, "ry": 0, "rz": 0}},
+                "geom": _default_segment(frame_height),
+                "connections": [{"to": edge.get("to", ""), "type": edge.get("type", "corner")}],
+            }
+            rivo_config["elements"].append(element)
 
     return rivo_config
 
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Map ConfigurationSnapshot to RivoExportConfig JSON.")
+    parser.add_argument("snapshot", help="Path to source snapshot JSON file.")
+    parser.add_argument("--project-id", default="demo-proj", help="Project identifier for export metadata.")
+    parser.add_argument(
+        "--output",
+        help="Output path for mapped JSON. If omitted, prints mapped JSON to stdout.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv or sys.argv[1:])
+    snapshot_path = Path(args.snapshot)
+
+    try:
+        snapshot_data = json.loads(snapshot_path.read_text(encoding="utf-8"))
+        mapped = map_snapshot_to_export_config(snapshot_data, args.project_id)
+    except Exception as exc:  # noqa: BLE001
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if args.output:
+        output_path = Path(args.output)
+        output_path.write_text(json.dumps(mapped, ensure_ascii=False, indent=2), encoding="utf-8")
+        print(output_path)
+    else:
+        print(json.dumps(mapped, ensure_ascii=False, indent=2))
+
+    return 0
+
+
 if __name__ == "__main__":
-    # Test mapping
-    stub_snapshot = {
-        "stateId": str(uuid4()),
-        "dimensions": {"width": 900, "height": 2600, "depth": 150},
-        "bom": [
-            {"article": "100001.1", "qty": 2000, "uom": "mm", "comment": "Profile length"}
-        ],
-        "graph": {
-            "rootNode": "root-1",
-            "edges": [
-                {"from": "root-1", "to": "child-1", "type": "inline"}
-            ]
-        }
-    }
-    out = map_snapshot_to_export_config(stub_snapshot, "demo-proj")
-    print("Mapped Config:")
-    print(json.dumps(out, indent=2))
+    raise SystemExit(main())

--- a/scripts/export_passport.py
+++ b/scripts/export_passport.py
@@ -1,7 +1,12 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
 import json
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
 
 PASSPORT_TEMPLATE = """# ТЕХНИЧЕСКИЙ ПАСПОРТ ИЗДЕЛИЯ
 **Проект:** {project_id}
@@ -17,54 +22,92 @@ PASSPORT_TEMPLATE = """# ТЕХНИЧЕСКИЙ ПАСПОРТ ИЗДЕЛИЯ
 - Шаг стоек: {stud_step} мм
 
 ## 3. Гарантии и требования
-- Гарантия на инсталляции RIVO Set — 10 лет.
-- Рекомендуется фильтр механической очистки ≤ 100 мкм.
-- Максимальное давление арматуры: ≤ 6 бар (ГОСТ 2874-82).
+- Гарантия на инсталляции RIVO Set - 10 лет.
+- Рекомендуется фильтр механической очистки <= 100 мкм.
+- Максимальное давление арматуры: <= 6 бар (ГОСТ 2874-82).
 
 ## 4. Правила монтажа (RIVO Fix)
-Любая нагрузка от оборудования/обшивки должна иметь непрерывный путь передачи: оборудование → крепёж/узел → профиль → опора/анкер → основание.
+Любая нагрузка от оборудования/обшивки должна иметь непрерывный путь передачи: оборудование -> крепеж/узел -> профиль -> опора/анкер -> основание.
 
 ---
 Документ сгенерирован автоматически: {current_time}
 """
 
-def generate_passport(rivo_config: dict, output_path: str):
-    meta = rivo_config.get("meta", {})
-    frame = rivo_config.get("frame", {})
-    bom_lines = rivo_config.get("bom", {}).get("lines", [])
 
-    bom_table = "| Артикул | Кол-во | Ед. изм. | Примечание |\n|---|---|---|---|\n"
+def _md_cell(value: Any) -> str:
+    text = str(value if value is not None else "")
+    return text.replace("|", "\\|").replace("\n", " ").strip()
+
+
+def _build_bom_table(bom_lines: list[dict[str, Any]]) -> str:
+    rows = ["| Артикул | Кол-во | Ед. изм. | Примечание |", "|---|---|---|---|"]
     for line in bom_lines:
-        bom_table += f"| {line.get('article', '')} | {line.get('qty', 0)} | {line.get('uom', 'шт')} | {line.get('comment', '')} |\n"
+        rows.append(
+            "| {article} | {qty} | {uom} | {comment} |".format(
+                article=_md_cell(line.get("article", "")),
+                qty=_md_cell(line.get("qty", 0)),
+                uom=_md_cell(line.get("uom", "шт")),
+                comment=_md_cell(line.get("comment", "")),
+            )
+        )
+    return "\n".join(rows)
+
+
+def _derive_output_path(config_path: Path) -> Path:
+    source = str(config_path)
+    if source.endswith(".rivo.json"):
+        return Path(source.removesuffix(".rivo.json") + ".passport.md")
+    return config_path.with_suffix(config_path.suffix + ".passport.md")
+
+
+def generate_passport(rivo_config: dict[str, Any], output_path: Path) -> Path:
+    if not isinstance(rivo_config, dict):
+        raise ValueError("rivo_config must be a dictionary")
+
+    meta = rivo_config.get("meta", {}) if isinstance(rivo_config.get("meta"), dict) else {}
+    frame = rivo_config.get("frame", {}) if isinstance(rivo_config.get("frame"), dict) else {}
+    bom = rivo_config.get("bom", {}) if isinstance(rivo_config.get("bom"), dict) else {}
+    bom_lines = [line for line in bom.get("lines", []) if isinstance(line, dict)] if isinstance(bom.get("lines"), list) else []
 
     report = PASSPORT_TEMPLATE.format(
         project_id=meta.get("projectId", "N/A"),
         date=meta.get("createdAt", "N/A"),
         author=meta.get("author", "N/A"),
-        bom_table=bom_table,
+        bom_table=_build_bom_table(bom_lines),
         frame_type=frame.get("type", "N/A"),
         width=frame.get("width", 0),
         height=frame.get("height", 0),
         depth=frame.get("depth", 0),
         stud_step=frame.get("studStep", 0),
-        current_time=datetime.now().isoformat()
+        current_time=datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
     )
 
-    with open(output_path, 'w', encoding='utf-8') as f:
-        f.write(report)
-    
-    print(f"Passport successfully written to {output_path}")
+    output_path.write_text(report, encoding="utf-8")
+    return output_path
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate markdown technical passport from Rivo export JSON.")
+    parser.add_argument("config", help="Path to .rivo.json (or compatible) input file.")
+    parser.add_argument("-o", "--output", help="Output markdown path. Default: <input>.passport.md")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv or sys.argv[1:])
+    config_path = Path(args.config)
+    output_path = Path(args.output) if args.output else _derive_output_path(config_path)
+
+    try:
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+        written = generate_passport(config, output_path)
+    except Exception as exc:  # noqa: BLE001
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    print(written)
+    return 0
+
 
 if __name__ == "__main__":
-    if len(sys.argv) > 1:
-        config_path = sys.argv[1]
-    else:
-        config_path = "../research/RIVO_Deliverables_Passport_DXF_IFC_JSON/05_sample_project.rivo.json"
-    
-    try:
-        with open(config_path, 'r', encoding='utf-8') as f:
-            config = json.load(f)
-        output_file = config_path.replace(".rivo.json", ".passport.md")
-        generate_passport(config, output_file)
-    except Exception as e:
-        print(f"Error processing {config_path}: {e}")
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Hardened export scripts for mapping/passport/DXF with production-safe CLI behavior and deterministic processing.
- Issue: #3

## Task Routing
- task_type: T7
- complexity: C2
- path: Quality Path

## Lock
- lock_paths: scripts/export_mapping.py,scripts/export_passport.py,scripts/export_dxf.py
- lock_owner: 8mirroz
- lock_type: file
- lock_expiry: 2026-02-28

## Contracts
- contracts_changed: no
- breaking_change: no

## Risk
- risk: low

## Checks
- [x] Contracts validated
- [ ] OpenAPI lint
- [x] Lock check passed (scope verified locally)
- [x] Required tests passed (`py_compile` + export smoke)